### PR TITLE
Re-add support for primary keys to support incremental/log-based updates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,9 +26,6 @@ jobs:
       - name: Setup virtual environment
         run: make venv
 
-      - name: Pylinting
-        run: make pylint
-
       - name: Unit Tests
         run: make unit_test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ 3.6, 3.7, 3.8 ]
+        python-version: [ 3.9 ]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
-
-      - name: Start PG test container
-        run: docker-compose up -d --build db
 
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@v2
@@ -39,6 +36,3 @@ jobs:
         env:
           LOGGING_CONF_FILE: ./sample_logging.conf
         run: make integration_test
-
-      - name: Shutdown PG test container
-        run: docker-compose down

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="target-duckdb",
-    version="0.4.0",
+    version="0.4.1",
     description="Singer.io target for loading data into DuckDB",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/target_duckdb/__init__.py
+++ b/target_duckdb/__init__.py
@@ -389,8 +389,9 @@ def load_stream_batch(
     if row_count[stream] > 0:
         flush_records(stream, records_to_load, row_count[stream], db_sync, temp_dir)
 
-    # Load finished, create indices if required
-    db_sync.create_indices(stream)
+    # NOTE(jwills): taking index creation out for now as it causes more headaches than it's
+    # worth for DuckDB; see https://github.com/duckdb/duckdb/issues/3265
+    # db_sync.create_indices(stream)
 
     # Delete soft-deleted, flagged rows - where _sdc_deleted at is not null
     if delete_rows:

--- a/target_duckdb/db_sync.py
+++ b/target_duckdb/db_sync.py
@@ -14,6 +14,7 @@ def camelize(string: str, uppercase_first_letter: bool = True) -> str:
     else:
         return string[0].lower() + camelize(string)[1:]
 
+
 # pylint: disable=fixme
 def column_type(schema_property):
     property_type = schema_property["type"]
@@ -64,9 +65,7 @@ def flatten_key(k, parent_key, sep):
     inflected_key = full_key.copy()
     reducer_index = 0
     while len(sep.join(inflected_key)) >= 63 and reducer_index < len(inflected_key):
-        reduced_key = re.sub(
-            r"[a-z]", "", camelize(inflected_key[reducer_index])
-        )
+        reduced_key = re.sub(r"[a-z]", "", camelize(inflected_key[reducer_index]))
         inflected_key[reducer_index] = (
             reduced_key if len(reduced_key) > 1 else inflected_key[reducer_index][0:3]
         ).lower()
@@ -337,7 +336,6 @@ class DbSync:
             for name in self.flatten_schema
         ]
 
-
     def load_rows(self, records, count):
         stream_schema_message = self.stream_schema_message
         stream = stream_schema_message["stream"]
@@ -352,7 +350,7 @@ class DbSync:
         insert_sql = "INSERT INTO {} ({}) VALUES ({})".format(
             temp_table,
             ", ".join(self.column_names()),
-            ", ".join(["?" for x in self.column_names()])
+            ", ".join(["?" for x in self.column_names()]),
         )
         self.logger.debug(insert_sql)
         for record in records:
@@ -425,7 +423,11 @@ class DbSync:
         ]
 
         if len(stream_schema_message["key_properties"]) > 0:
-            primary_key = ["PRIMARY KEY ({})".format(', '.join(primary_column_names(stream_schema_message)))]
+            primary_key = [
+                "PRIMARY KEY ({})".format(
+                    ", ".join(primary_column_names(stream_schema_message))
+                )
+            ]
         else:
             primary_key = []
 

--- a/tests/integration/test_target_duckdb.py
+++ b/tests/integration/test_target_duckdb.py
@@ -689,14 +689,16 @@ class TestIntegration(unittest.TestCase):
                     "c_array": json.dumps([1, 2, 3]),
                     "c_object": json.dumps({"key_1": "value_1"}),
                     "c_object_with_props": json.dumps({"key_1": "value_1"}),
-                    "c_nested_object": json.dumps({
-                        "nested_prop_1": "nested_value_1",
-                        "nested_prop_2": "nested_value_2",
-                        "nested_prop_3": {
-                            "multi_nested_prop_1": "multi_value_1",
-                            "multi_nested_prop_2": "multi_value_2",
-                        },
-                    }),
+                    "c_nested_object": json.dumps(
+                        {
+                            "nested_prop_1": "nested_value_1",
+                            "nested_prop_2": "nested_value_2",
+                            "nested_prop_3": {
+                                "multi_nested_prop_1": "multi_value_1",
+                                "multi_nested_prop_2": "multi_value_2",
+                            },
+                        }
+                    ),
                 }
             ],
         )


### PR DESCRIPTION
…and remove meta-column index creation for the time being b/c it's more trouble than it's worth until DuckDB indexes have transactional deletes implemented. Fixes #11 (I think.)