### PR TITLE
Use quotes for database and schema name

### DIFF
--- a/target_duckdb/db_sync.py
+++ b/target_duckdb/db_sync.py
@@ -327,9 +327,9 @@ class DbSync:
         if without_schema:
             return f'"{pg_table_name.lower()}"'
         elif self.catalog_name:
-            return f'{self.catalog_name}.{self.schema_name}."{pg_table_name.lower()}"'
+            return f'"{self.catalog_name}"."{self.schema_name}"."{pg_table_name.lower()}"'
         else:
-            return f'{self.schema_name}."{pg_table_name.lower()}"'
+            return f'"{self.schema_name}"."{pg_table_name.lower()}"'
 
     def record_primary_key_string(self, record):
         if len(self.stream_schema_message["key_properties"]) == 0:

--- a/target_duckdb/db_sync.py
+++ b/target_duckdb/db_sync.py
@@ -530,9 +530,9 @@ class DbSync:
 
         if len(schema_rows) == 0:
             if catalog_name:
-                query = f"CREATE SCHEMA IF NOT EXISTS {catalog_name}.{schema_name}"
+                query = f'CREATE SCHEMA IF NOT EXISTS "{catalog_name}"."{schema_name}"'
             else:
-                query = f"CREATE SCHEMA IF NOT EXISTS {schema_name}"
+                query = f'CREATE SCHEMA IF NOT EXISTS "{schema_name}"'
 
             self.logger.info(
                 "Schema '%s' does not exist. Creating... %s", schema_name, query


### PR DESCRIPTION
Without quotes, duckdb complains about table creation for database/schema names starting with a number. Say an uuid.

## Problem

For a database named "1.duckdb" the table creation logic fails with duckdb error `Error: Parser Error: syntax error at or near "1"`

## Proposed changes

Add quotes around database and schema names to allow for numerical prefixed database/schemas

## Types of changes

What types of changes does your code introduce to PipelineWise?
_Put an `x` in the boxes that apply_

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)
