### PR TITLE
fix: set line terminator chars to correspond with csv writer

### DIFF
--- a/target_duckdb/db_sync.py
+++ b/target_duckdb/db_sync.py
@@ -384,7 +384,7 @@ class DbSync:
             )
             for record in records:
                 csvwriter.writerow(self.record_to_flattened(record))
-        cur.execute("COPY {} FROM '{}'".format(temp_table, temp_file_csv))
+        cur.execute("COPY {} FROM '{}' WITH (new_line '\\r\\n')".format(temp_table, temp_file_csv))
 
         if len(self.stream_schema_message["key_properties"]) > 0:
             cur.execute(self.update_from_temp_table(temp_table))


### PR DESCRIPTION
## Problem

Data with certain new line characters throws `duckdb.duckdb.InvalidInputException: Invalid Input Error: Wrong NewLine Identifier. Expecting \r\n` as described in #32.

## Proposed changes

The Pythons `csv.writer` by default sets it's parameter of `lineterminator` to `'\r\n'` when writing the CSV files. This is not correctly reflected in DuckDB when trying to load these CSV files as it automatically assumes the new line character by contents of the file which is incorrect under certain circumstances. Setting the `new_line` argument in DuckDBs `CSV COPY` manually prevents this wrong assumption.


## Types of changes

What types of changes does your code introduce to PipelineWise?

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation Update (if none of the other choices apply)