### PR TITLE
Fix/pin duckdb version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ with open("README.md") as f:
 
 setup(
     name="target-duckdb",
-    version="0.8.0",
+    version="0.8.1",
     description="Singer.io target for loading data into DuckDB",
     long_description=long_description,
     long_description_content_type="text/markdown",

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ setup(
     py_modules=["target_duckdb"],
     install_requires=[
         "jsonschema>=3.2.0",
-        "duckdb>=1.0.0",
+        "duckdb~=1.1.0",
     ],
     extras_require={
         "test": [


### PR DESCRIPTION
## Problem

Currently the DuckDB version is pinned to a major. With the update to 1.2.0 there is a temporary incompatibility with MotherDuck.

## Proposed changes

Pin DuckDB to 1.1.x in version 0.8.1 of this target. Release another version 0.9.0 later with DuckDB pinned to 1.2.x to make sure we ensure compatibility.


## Types of changes

- [x ] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ x] Documentation Update (if none of the other choices apply)


## Checklist

- [x ] Description above provides context of the change
- [ x] I have added tests that prove my fix is effective or that my feature works
- [ x] Unit tests for changes (not needed for documentation changes)
- [ x] CI checks pass with my changes
- [ x] Bumping version in `setup.py` is an individual PR and not mixed with feature or bugfix PRs
- [ ] Commit message/PR title starts with `[AP-NNNN]` (if applicable. AP-NNNN = JIRA ID)
- [ ] Branch name starts with `AP-NNN` (if applicable. AP-NNN = JIRA ID)
- [ ] Commits follow "[How to write a good git commit message](http://chris.beams.io/posts/git-commit/)"
- [ x] Relevant documentation is updated including usage instructions