### PR TITLE
Fix: first record silently dropped due to CSV header auto-detection

### DIFF
--- a/target_duckdb/db_sync.py
+++ b/target_duckdb/db_sync.py
@@ -386,7 +386,7 @@ class DbSync:
             )
             for record in records:
                 csvwriter.writerow(self.record_to_flattened(record))
-        cur.execute("COPY {} FROM '{}' WITH (HEADER 0, new_line '\\r\\n')".format(temp_table, temp_file_csv))
+        cur.execute("COPY {} FROM '{}' WITH (HEADER false, new_line '\\r\\n')".format(temp_table, temp_file_csv))
 
         if len(self.stream_schema_message["key_properties"]) > 0:
             cur.execute(self.update_from_temp_table(temp_table))

--- a/target_duckdb/db_sync.py
+++ b/target_duckdb/db_sync.py
@@ -386,7 +386,7 @@ class DbSync:
             )
             for record in records:
                 csvwriter.writerow(self.record_to_flattened(record))
-        cur.execute("COPY {} FROM '{}' WITH (new_line '\\r\\n')".format(temp_table, temp_file_csv))
+        cur.execute("COPY {} FROM '{}' WITH (HEADER 0, new_line '\\r\\n')".format(temp_table, temp_file_csv))
 
         if len(self.stream_schema_message["key_properties"]) > 0:
             cur.execute(self.update_from_temp_table(temp_table))


### PR DESCRIPTION
## Summary

- DuckDB's `COPY FROM` [auto-detects CSV headers](https://duckdb.org/docs/stable/data/csv/auto_detection) by default. Since the CSV files generated by `load_rows` have no header row, the first data row was being interpreted as a header and silently discarded — resulting in exactly **one record lost per stream per batch**.
- Fix: add `HEADER 0` to the [`COPY` options](https://duckdb.org/docs/stable/sql/statements/copy) so all rows are treated as data.

## Test plan

- [x] Loaded 255 Singer RECORD messages into a fresh DuckDB database
- [x] Verified all 255 rows are present in the target table (previously only 254)
- [x] Confirmed the previously missing first record (employeeId=58) is now loaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)